### PR TITLE
In browser always assume we are connected

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ var os = require('os');
 module.exports = function() {
   var interfaces;
 
+  // in browser always assume we are connected
+  if (typeof localStorage !== "undefined" || localStorage !== null)
+    return true;
+
   try {
     interfaces = os.networkInterfaces();
   } catch (e) {


### PR DESCRIPTION
In a browser has-network will always return false as it is now. This changed to always true. 