### PR TITLE
Fix ReferenceError: localStorage is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function() {
   var interfaces;
 
   // in browser always assume we are connected
-  if (typeof localStorage !== "undefined" || localStorage !== null)
+  if (typeof localStorage !== "undefined" && localStorage !== null)
     return true;
 
   try {


### PR DESCRIPTION
Line 13 tries to access global var "localStorage", which obviously is not defined outside of browsers. I guess you meant to use `&&` instead of `||` ?